### PR TITLE
Refactor and Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/mock-es
+cmd/mock-es/mock-es

--- a/README.md
+++ b/README.md
@@ -1,46 +1,96 @@
 # mock-es
-A mock elasticsearch server for testing.  This provides the absolute minimum responses for something like filebeat to send bulk requests to and to provide a response.  The data is thrown away.  By default successful responses are sent for all data.
 
-It is also possible to return errors.  It is possible to configure so that each POST to the bulk endpoint can result in an error.  It is also possible to configure it so that each create action in the bulk request has the possibility of an error.  Any other action always return StatusOK.
+## What is it
 
-| Flag      | Meaning                                                                           |
-|-----------|-----------------------------------------------------------------------------------|
-| -a string | address to listen on ip:port (default ":9200")                                    |
-| -d uint   | percent chance StatusConflict is returned for create action                       |
-| -l uint   | percent chance StatusEntityTooLarge is returned for POST method on _bulk endpoint |
-| -n uint   | percent chance StatusNotAcceptable is returned for create action                  |
-| -t uint   | percent chance StatusTooManyRequests is returned for create action                |
+An API and CLI application for running a mock elasticsearch server.  The server implements the absoulte minimum for something like `filebeat` to connect to it and send bulk requests.  The data that is sent is thrown away.  The server can be configured to send error responses but by default all actions succeed.
 
-`-d`, `-n`, and `-t` cannot total more than 100 percent, if the total is less than 100, the remaining percentage chance is for StatusOK.
+## Use cases
 
-eg:
+If you are developing Dashboards for Elastic Agent and want to make sure that the errors Dashboards display correctly you could start `mock-es` configured to return errors and then direct the integrations to send data to `mock-es`.  This would allow you to prove that when errors occur the Dashboards are populated correctly.
 
-`-d 20 -n 10 -t 5` would result in a 20 percent chance StatusConflict, 10 percent chance StatusNotAcceptable, 5 percent chance StatusTooManyRequests and 65 percent chance that StatusOK would be returned for each create action in the bulk request
+You are developing a feature that splits the batch when `StatusEntityTooLarge` is returned.  You could write a unit test that start the server from the API with a 100% chance of returning that error, then send data, making sure that the split happens as expected and checking the metrics that `StatusEntityTooLarge` was returned.
 
-`-l` cannot be larger than 100, if the total is less than 100, the remaining percentage chance is for StatusOK
 
-eg:
-
-`-l 25`  would result in a 25 percent chance that each POST to the bulk endpoint would result in StatusEntityTooLarge, the remaining 75 percent would be StatusOK.
-
-## Building
+## Building the CLI server
 
 ```
+git clone https://github.com/leehinman/mock-es.git
+cd mock-es/cmd/mock-es
 go build
 ```
 
+## Running the CLI server
 
-## Running
-
-Always return success
+To run the server with defaults (port 9200, no TLS, always succeed).  Simply run the executable:
 
 ```
 ./mock-es
 ```
 
+Options are used to change the behavior.
 
-20 percent chance for StatusTooManyRequests (429 response)
+### General options
+
+| Flag                | Meaning                                                                                       |
+|---------------------|-----------------------------------------------------------------------------------------------|
+| -addr string        | address to listen on ip:port (default ":9200")                                                |
+| -clusteruuid string | Cluster UUID of Elasticsearch we are mocking, needed if beat is being monitored by metricbeat |
+| -metrics duration   | Interval to print metrics to stdout, 0 is no metrics                                          |
+
+
+### TLS Options
+
+Both `certfile` and `keyfile` are needed to enable TLS
+
+| Flag             | Meaning                                             |
+|------------------|-----------------------------------------------------|
+| -certfile string | path to PEM certificate file, empty sting is no TLS |
+| -keyfile string  | path to PEM private key file, empty sting is no TLS |
+
+
+### Error Option
+
+| Flag           | Meaning                                                                           |
+|----------------|-----------------------------------------------------------------------------------|
+| -toolarge uint | percent chance StatusEntityTooLarge is returned for POST method on _bulk endpoint |
+| -dup uint      | percent chance StatusConflict is returned for create action                       |
+| -nonindex uint | percent chance StatusNotAcceptable is returned for create action                  |
+| -toomany uint  | percent chance StatusTooManyRequests is returned for create action                |
+
+
+`-toolarge` will be for the entire POST to the _bulk endpoint.  The others are for each individual create action in the bulk request.  `-toolarge` cannot be larger than 100.  The sum of `-dup`, `-noindex`, and `-toomany` cannot be larger than 100.
+
+#### Example
 
 ```
-./mock-es -t 20
+./mock-es -toolarge 20 -dup 5 -nonindex 10 -toomany 15
 ```
+
+This means there is a 20% chance the POST to _bulk will return StatusEntityTooLarge, and an 80% chance it will succeed.  There is a 5% chance that the create action will return StatusConflict (duplicate entry), a 10% chance that the create action will return StatusNotAcceptable (non index) and a 15% chance that the create action will return StatusTooManyRequests.
+
+
+## Using in a Unit Test
+
+Rather than trying to build and shell out to run the `mock-es` executable it is much easier to just create the server in your tests.  A minimal example would be:
+
+``` go
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/leehinman/mock-es/pkg/api"
+	"github.com/rcrowley/go-metrics"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.Handle("/", api.NewAPIHandler(uuid.New(), "", metrics.DefaultRegistry, time.Now().Add(24 *time.Hour) , 0, 0, 0, 0))
+	if err := http.ListenAndServe("localhost:9200", mux); err != nil {
+		if err != http.ErrServerClosed {
+			panic(err)
+		}
+	}
+}
+```
+

--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ go 1.21.9
 require github.com/google/uuid v1.6.0
 
 require github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+
+require github.com/mileusna/useragent v1.3.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
+github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,7 +22,7 @@ type BulkResponse struct {
 	Items  []map[string]any `json:"items,omitempty"`
 }
 
-// APIHandler docstring
+// APIHandler struct.  Use NewAPIHandler to make sure it is filled in correctly for use.
 type APIHandler struct {
 	ActionOdds    [100]int
 	MethodOdds    [100]int
@@ -106,6 +106,7 @@ func NewAPIHandler(uuid uuid.UUID, clusterUUID string, metricsRegistry metrics.R
 	return h
 }
 
+//ServeHTTP looks at the request and routes it to the correct handler function
 func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/":


### PR DESCRIPTION
- Move api.go to pkg/api, this makes it easier to import
- add support for cluster uuid, this is necessary if a beat is using mock-es as it's output, and it is being monitored by metricbeat.  Without the cluster uuid, no monitoring is collected.
- add flags so TLS can be used
- mock-es will now report it's version to be the same as the connecting clients in the root handler
- changed flags to be longer and hopefully more meaningful
- updated documentation with new flags and example of how to use in a unit test